### PR TITLE
Added "\Magento\Framework\View\Asset\Remote" as an valid type for ord…

### DIFF
--- a/View/Asset/PropertyGroup.php
+++ b/View/Asset/PropertyGroup.php
@@ -17,8 +17,14 @@ class PropertyGroup
 
         $aRealResult = [];
         foreach($result as $sAssetPath => $_oFile) {
-            $oFile = new File();
-            $oFile->setRealFile($_oFile);
+            // Fix for remote files
+            if ($_oFile instanceof \Magento\Framework\View\Asset\File) {
+                $oFile = new File();
+                $oFile->setRealFile($_oFile);
+            } else if ($_oFile instanceof \Magento\Framework\View\Asset\Remote) {
+                $oFile = new Remote();
+                $oFile->setRealRemoteFile($_oFile);
+            }
 
             if(isset($aProperties['attributes']) && isset($aProperties['attributes']['order'])) {
                 $oFile->setOrder((int)$aProperties['attributes']['order']);

--- a/View/Asset/Remote.php
+++ b/View/Asset/Remote.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Quickshiftin\Assetorderer\View\Asset;
+
+
+class Remote
+{
+    private $_iOrder = 1;
+    private $_oRealRemoteFile;
+
+    public function __call($sMethod, array $aArgs=[])
+    {
+        return call_user_func_array([$this->_oRealRemoteFile, $sMethod], $aArgs);
+    }
+
+    public function setRealRemoteFile(\Magento\Framework\View\Asset\Remote $oRealRemoteFile) {
+        $this->_oRealRemoteFile = $oRealRemoteFile;
+    }
+
+    public function getOrder() { return $this->_iOrder; }
+    public function setOrder($iOrder) { $this->_iOrder = $iOrder; }
+}


### PR DESCRIPTION
This adds the remote asset type as an valid file type to allow correct ordering of css files
Fixes #3 

