### PR TITLE
Fixed dependency injection in function failure

### DIFF
--- a/View/Asset/File.php
+++ b/View/Asset/File.php
@@ -11,7 +11,7 @@ class File
         return call_user_func_array([$this->_oRealFile, $sMethod], $aArgs);
     }
 
-    public function setRealFile(\Magento\Framework\View\Asset\File $oRealFile) {
+    public function setRealFile($oRealFile) {
         $this->_oRealFile = $oRealFile;
     }
 


### PR DESCRIPTION
Magento 2.1.5 was injecting 2 different classes:

A file injection can be:

\Magento\Framework\View\Asset\Remote
\Magento\Framework\View\Asset\File

so i removed the setRealFile dependency.