### PR TITLE
Deleted acl tag because it breaks the acl tree

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -2,9 +2,9 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Acl/etc/acl.xsd">
     <acl>
         <resources>
-            <resource id="Magento_Adminhtml::admin">
-               <!--AddMenuAcl-->
-            </resource>
+            <!--<resource id="Magento_Adminhtml::admin">-->
+               <!--&lt;!&ndash;AddMenuAcl&ndash;&gt;-->
+            <!--</resource>-->
         </resources>
     </acl>
 </config>


### PR DESCRIPTION
In the magento2 backend (v2.1.6) the acl tree breaks when having empty `<resource></resource>` tags. So i commented them out as quick fix.